### PR TITLE
Fix simultaneous replay crash with missing samples

### DIFF
--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -42,11 +42,30 @@ const AFTER_PITCH_HOLD_SEC = 0.7 + 1.5;
 const TRAJECTORY_LEAD_SEC = 0.05;
 const TRAIL_DELAY_S = 0.12;
 const EPS = 1e-4;
+const DEFAULT_PITCH_DURATION = 0.6;
 
 function worldFromSample(sample: { x: number; y: number; z: number }): THREE.Vector3 {
   // Statcast: x(左右), y(捕手方向への距離), z(高さ)
   // World   : x(左右), y(高さ), z(奥行き) ・・・ y と z を入れ替え、z は符号反転
   return new THREE.Vector3(sample.x, sample.z, -sample.y);
+}
+
+function resolveBaseSpeedFactor(releaseSpeed: number | undefined): number {
+  if (!Number.isFinite(releaseSpeed) || !releaseSpeed || releaseSpeed <= 0) {
+    return 1;
+  }
+  const normalised = releaseSpeed / 90;
+  if (!Number.isFinite(normalised) || normalised <= 0) {
+    return 1;
+  }
+  return Math.max(0.4, normalised);
+}
+
+function resolvePitchDuration(pitch: Pitch): number {
+  if (Number.isFinite(pitch.duration) && pitch.duration > EPS) {
+    return pitch.duration;
+  }
+  return DEFAULT_PITCH_DURATION;
 }
 
 function resolvePitchColor(pitch: Pitch | undefined): string {
@@ -411,7 +430,7 @@ function Ball({
       return;
     }
 
-    const baseSpeedFactor = Math.max(0.4, pitch.release_speed / 90);
+    const baseSpeedFactor = resolveBaseSpeedFactor(pitch.release_speed);
     const scaledDelta = delta * playbackSpeed * baseSpeedFactor;
 
     const nextTime = Math.min(pitch.duration, timeRef.current + scaledDelta);
@@ -463,17 +482,27 @@ function Ball({
 }
 
 function MultiReplayTrajectory({ pitch, multiTime }: { pitch: Pitch; multiTime: number }) {
-  const baseSpeedFactor = useMemo(() => Math.max(0.4, pitch.release_speed / 90), [pitch.release_speed]);
+  const baseSpeedFactor = useMemo(
+    () => resolveBaseSpeedFactor(pitch.release_speed),
+    [pitch.release_speed]
+  );
 
   const points = useMemo(() => {
     const samples = pitch.samples;
     if (samples.length === 0) return [];
-    const duration = Math.max(EPS, pitch.duration);
+    const duration = resolvePitchDuration(pitch);
     const effectiveTime = multiTime - TRAJECTORY_LEAD_SEC;
-    if (effectiveTime <= 0) {
+    if (!Number.isFinite(effectiveTime) || effectiveTime <= 0) {
       return [];
     }
-    const pitchTime = Math.min(duration, effectiveTime * baseSpeedFactor);
+    const scaledTime = effectiveTime * baseSpeedFactor;
+    if (!Number.isFinite(scaledTime)) {
+      return [];
+    }
+    const pitchTime = Math.min(duration, Math.max(0, scaledTime));
+    if (!Number.isFinite(pitchTime)) {
+      return [];
+    }
     const tVisible = Math.max(0, pitchTime - TRAIL_DELAY_S);
     const progress = Math.min(1, tVisible / duration);
 
@@ -507,11 +536,19 @@ function MultiReplayTrajectory({ pitch, multiTime }: { pitch: Pitch; multiTime: 
 
 function MultiReplayBall({ pitch }: { pitch: Pitch }) {
   const meshRef = useRef<THREE.Mesh>(null);
-  const baseSpeedFactor = useMemo(() => Math.max(0.4, pitch.release_speed / 90), [pitch.release_speed]);
+  const baseSpeedFactor = useMemo(
+    () => resolveBaseSpeedFactor(pitch.release_speed),
+    [pitch.release_speed]
+  );
 
   useEffect(() => {
     if (!meshRef.current) return;
-    const start = worldFromSample(pitch.samples[0]);
+    const firstSample = pitch.samples[0];
+    if (!firstSample) {
+      meshRef.current.visible = false;
+      return;
+    }
+    const start = worldFromSample(firstSample);
     meshRef.current.position.copy(start);
     meshRef.current.visible = false;
   }, [pitch]);
@@ -526,16 +563,30 @@ function MultiReplayBall({ pitch }: { pitch: Pitch }) {
     }
 
     if (!meshRef.current) return;
+    if (pitch.samples.length === 0) {
+      meshRef.current.visible = false;
+      return;
+    }
 
     const elapsed = state.multiReplayTime - TRAJECTORY_LEAD_SEC;
     if (elapsed <= 0) {
       meshRef.current.visible = false;
-      const start = worldFromSample(pitch.samples[0]);
-      meshRef.current.position.copy(start);
+      const firstSample = pitch.samples[0];
+      if (firstSample) {
+        const start = worldFromSample(firstSample);
+        meshRef.current.position.copy(start);
+      }
       return;
     }
 
-    const pitchTime = Math.min(pitch.duration, elapsed * baseSpeedFactor);
+    const duration = resolvePitchDuration(pitch);
+    const scaledTime = elapsed * baseSpeedFactor;
+    const pitchTime = Math.min(duration, Math.max(0, Number.isFinite(scaledTime) ? scaledTime : 0));
+    if (!Number.isFinite(pitchTime)) {
+      meshRef.current.visible = false;
+      return;
+    }
+
     const sample = getPositionAtTime(pitch.samples, pitchTime);
     const position = worldFromSample(sample);
     meshRef.current.visible = true;
@@ -584,8 +635,9 @@ function MultiReplayScene() {
   const totalDuration = useMemo(() => {
     if (multiReplayPitches.length === 0) return 0;
     return multiReplayPitches.reduce((max, pitch) => {
-      const baseFactor = Math.max(0.4, pitch.release_speed / 90);
-      const required = TRAJECTORY_LEAD_SEC + pitch.duration / baseFactor + AFTER_PITCH_HOLD_SEC;
+      const baseFactor = resolveBaseSpeedFactor(pitch.release_speed);
+      const duration = resolvePitchDuration(pitch);
+      const required = TRAJECTORY_LEAD_SEC + duration / baseFactor + AFTER_PITCH_HOLD_SEC;
       return Math.max(max, required);
     }, 0);
   }, [multiReplayPitches]);

--- a/src/state/useStore.multi.test.ts
+++ b/src/state/useStore.multi.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, beforeEach, afterEach, it } from 'vitest';
+import { useStore } from './useStore';
+import type { Pitch } from '../engine/statcast.types';
+
+const sampleCsv = readFileSync(new URL('../../fixtures/sample_statcast.csv', import.meta.url), 'utf-8');
+
+function clonePitch(pitch: Pitch, overrides: Partial<Pitch>): Pitch {
+  return { ...pitch, ...overrides };
+}
+
+describe('multi replay start', () => {
+  beforeEach(() => {
+    useStore.getState().reset();
+    useStore.getState().loadFromCsv(sampleCsv);
+  });
+
+  afterEach(() => {
+    useStore.getState().reset();
+  });
+
+  it('activates multi replay with up to 10 pitches that have samples', () => {
+    const state = useStore.getState();
+    expect(state.pitches.length).toBeGreaterThan(0);
+
+    state.startMultiReplay();
+
+    const nextState = useStore.getState();
+    expect(nextState.multiReplayActive).toBe(true);
+    expect(nextState.multiReplayPitches.length).toBeGreaterThan(0);
+    expect(nextState.multiReplayPitches.length).toBeLessThanOrEqual(10);
+    expect(nextState.multiReplayPitches.every((pitch) => pitch.samples.length > 0)).toBe(true);
+    expect(nextState.multiReplayAtBatIndex).toBe(nextState.multiReplayPitches[0]?.atBatIndex);
+    expect(nextState.isPlaying).toBe(false);
+    expect(nextState.multiReplayTime).toBe(0);
+  });
+
+  it('ignores pitches without trajectory samples when starting multi replay', () => {
+    const baseState = useStore.getState();
+    const originalPitches = baseState.pitches.slice(0, 3);
+    const mutated = originalPitches.map((pitch, idx) =>
+      idx === 1 ? clonePitch(pitch, { samples: [] }) : pitch
+    );
+
+    const mutatedById = new Map(mutated.map((pitch) => [pitch.id, pitch]));
+    const patchedAtBats = baseState.atBats.map((atBat) => ({
+      ...atBat,
+      pitches: atBat.pitches.map((pitch) => mutatedById.get(pitch.id) ?? pitch),
+    }));
+
+    useStore.setState({
+      pitches: [...mutated, ...baseState.pitches.slice(3)],
+      atBats: patchedAtBats,
+    });
+
+    useStore.getState().startMultiReplay();
+    const nextState = useStore.getState();
+
+    expect(nextState.multiReplayPitches.some((pitch) => pitch.samples.length === 0)).toBe(false);
+    const filteredOut = nextState.multiReplayPitches.find((pitch) => pitch.id === mutated[1].id);
+    expect(filteredOut).toBeUndefined();
+  });
+
+  it('does not activate multi replay when no valid pitches are available', () => {
+    const { pitches } = useStore.getState();
+    const emptyPitches = pitches.slice(0, 2).map((pitch) => clonePitch(pitch, { samples: [] }));
+    const emptyMap = new Map(emptyPitches.map((pitch) => [pitch.id, pitch]));
+    useStore.setState((prev) => ({
+      ...prev,
+      pitches: emptyPitches,
+      atBats: prev.atBats.map((atBat) => ({
+        ...atBat,
+        pitches: atBat.pitches
+          .filter((pitch) => emptyMap.has(pitch.id))
+          .map((pitch) => emptyMap.get(pitch.id) as Pitch),
+      })),
+    }));
+
+    useStore.getState().startMultiReplay();
+    const nextState = useStore.getState();
+    expect(nextState.multiReplayActive).toBe(false);
+    expect(nextState.multiReplayPitches.length).toBe(0);
+  });
+});

--- a/src/state/useStore.ts
+++ b/src/state/useStore.ts
@@ -200,14 +200,20 @@ export const useStore = create<StoreState>((set, get) => ({
   startMultiReplay: () => {
     const { pitches } = get();
     if (pitches.length === 0) return;
-    const selected = pitches.slice(0, 10);
+
+    const selected = pitches
+      .slice(0, 10)
+      .filter((pitch) => Array.isArray(pitch.samples) && pitch.samples.length > 0);
+
     if (selected.length === 0) return;
-    const first = selected[0];
+
+    const firstValid = selected.find((pitch) => Number.isFinite(pitch.atBatIndex));
+
     set({
       multiReplayActive: true,
       multiReplayPitches: selected,
       multiReplayTime: 0,
-      multiReplayAtBatIndex: first?.atBatIndex,
+      multiReplayAtBatIndex: firstValid?.atBatIndex,
       isPlaying: false,
     });
   },


### PR DESCRIPTION
## Summary
- guard the simultaneous replay store logic against pitches that lack trajectory samples so we only launch valid tracks
- add defensive helpers in the 3D renderer to handle missing samples and non-finite speeds during multi-pitch playback
- cover the new multi-replay scenarios with store-level regression tests using the bundled sample CSV

## Testing
- npm run test *(fails: local vitest binary is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4478ae44c8326b093b5cc3b4d1756